### PR TITLE
Fixed issue where jQuery ran before images loaded

### DIFF
--- a/ppibfi_pinterest.js
+++ b/ppibfi_pinterest.js
@@ -1,4 +1,4 @@
-jQuery(window).ready(function(jQuery) {
+jQuery(window).load(function() {
 	jQuery('.pibfi_pinterest').each(function(index, element) {
 		var	$this = jQuery(this),
 				$theImage = jQuery($this.find('img:first-child')[0]),


### PR DESCRIPTION
Images aren't loaded when using a `(window).ready` event, switching to
`.load()` allows all images to load prior to running the button add code.

All the 'Pin It' buttons were showing up about in the middle of my images. The css `left:` value implied that the width of my images were all zero. I realized this was because the images hadn't loaded when the jQuery was running. Switching to the `jQuery(window).load` event solves the problem.

Also, you don't need to pass the `jQuery` object to the `load` event. You would only pass the `$` if you wanted to use it within the function. See [WordPress jQuery noConflict](http://codex.wordpress.org/Function_Reference/wp_enqueue_script#jQuery_noConflict_wrappers).
